### PR TITLE
explicit string cast for MongoDB name query

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
     - ROS_REPO=ros
   matrix:
     - ROS_DISTRO=melodic  TEST=clang-format,catkin_lint
-    - ROS_DISTRO=melodic
+    - ROS_DISTRO=melodic  BEFORE_SCRIPT="apt-get -qq install -y mongodb-server && service mongodb start"
 
 before_script:
   - git clone -q --depth=1 https://github.com/ros-planning/moveit_ci.git .moveit_ci

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,9 +58,7 @@ target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} ${MongoDB_LIBRARIES} $
 if(CATKIN_ENABLE_TESTING)
   add_executable(test_warehouse_ros_mongo_cpp test/test_warehouse_ros_mongo.cpp)
   target_link_libraries(test_warehouse_ros_mongo_cpp warehouse_ros_mongo ${GTEST_LIBRARIES})
-
-  # Disable unit test, because it hangs in Travis. TODO: Provide a mongodb server in Travis.
-  # add_rostest(test/warehouse_ros_mongo.test)
+  add_rostest(test/warehouse_ros_mongo.test)
 endif()
 
 install(PROGRAMS src/mongo_wrapper_ros.py DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION})

--- a/test/test_warehouse_ros_mongo.cpp
+++ b/test/test_warehouse_ros_mongo.cpp
@@ -99,7 +99,7 @@ TEST(MongoRos, MongoRos)
   // Simple query: find the pose with name 'qux' and return just its metadata
   // Since we're doing an equality check, we don't explicitly specify a predicate
   Query::Ptr q1 = coll.createQuery();
-  q1->append("name", "qux");
+  q1->append("name", std::string("qux"));
   vector<PoseMetaPtr> res = coll.queryList(q1, true);
   EXPECT_EQ(1u, res.size());
   EXPECT_EQ("qux", res[0]->lookupString("name"));
@@ -134,18 +134,18 @@ TEST(MongoRos, MongoRos)
 
   // Test findOne
   Query::Ptr q4 = coll.createQuery();
-  q4->append("name", "bar");
+  q4->append("name", std::string("bar"));
   EXPECT_EQ(p1, *coll.findOne(q4, false));
   EXPECT_DOUBLE_EQ(24, coll.findOne(q4, true)->lookupDouble("x"));
 
   Query::Ptr q5 = coll.createQuery();
-  q5->append("name", "barbar");
+  q5->append("name", std::string("barbar"));
   EXPECT_THROW(coll.findOne(q5, true), NoMatchingMessageException);
   EXPECT_THROW(coll.findOne(q5, false), NoMatchingMessageException);
 
   // Test update
   Metadata::Ptr m1 = coll.createMetadata();
-  m1->append("name", "barbar");
+  m1->append("name", std::string("barbar"));
   coll.modifyMetadata(q4, m1);
   EXPECT_EQ(3u, coll.count());
   EXPECT_THROW(coll.findOne(q4, false), NoMatchingMessageException);


### PR DESCRIPTION
For some reason, when calling `Query::append("name", "bar");` the string value is interpreted as boolean and `append(const std::string& name, const bool val)` is called in stead of `append(const std::string& name, const std::string& val)`. This makes the tests fail.
I have no explanation for this behaviour, but an explicit cast fixes the issue.